### PR TITLE
use correct path for build artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,9 @@ test_script:
   - dotnet test tests\LocalAppVeyor.Engine.UnitTests\LocalAppVeyor.Engine.UnitTests.csproj --configuration %configuration%
 
 artifacts:
-  - path: out_engine\*.nupkg
+  - path: LocalAppVeyor.Engine\out_engine\*.nupkg
     name: engine_packages
-  - path: out_console\*.nupkg
+  - path: LocalAppVeyor\out_console\*.nupkg
     name: console_packages
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,9 @@ test_script:
   - dotnet test tests\LocalAppVeyor.Engine.UnitTests\LocalAppVeyor.Engine.UnitTests.csproj --configuration %configuration%
 
 artifacts:
-  - path: LocalAppVeyor.Engine\out_engine\*.nupkg
+  - path: src\LocalAppVeyor.Engine\out_engine\*.nupkg
     name: engine_packages
-  - path: LocalAppVeyor\out_console\*.nupkg
+  - path: src\LocalAppVeyor\out_console\*.nupkg
     name: console_packages
 
 deploy:


### PR DESCRIPTION
[Build logs](https://ci.appveyor.com/project/joaope/localappveyor/build/job/mkm0ike8ml7ra0op) are showing:
```
Collecting artifacts...
No artifacts found matching 'out_engine\*.nupkg' path
No artifacts found matching 'out_console\*.nupkg' path
"NuGet" deployment has been skipped as environment variable has not matched ("appveyor_repo_tag" is "false", should be "true")
"NuGet" deployment has been skipped as environment variable has not matched ("appveyor_repo_tag" is "false", should be "true")
Build success
```

Running the build locally, the artifacts appear to be in LocalAppVeyor.Engin\out_engine and LocalAppVeyor\out_console respectively, so update the appveyor.yml file so it can find them.