### PR TITLE
allow multiple commands in a script block

### DIFF
--- a/src/LocalAppVeyor.Engine/Internal/Steps/ScriptBlockExecuterStep.cs
+++ b/src/LocalAppVeyor.Engine/Internal/Steps/ScriptBlockExecuterStep.cs
@@ -27,6 +27,7 @@ namespace LocalAppVeyor.Engine.Internal.Steps
             {
                 foreach (var scriptLine in scriptBlock)
                 {
+                    bool status;
                     if (string.IsNullOrEmpty(scriptLine.Script))
                     {
                         return true;
@@ -35,9 +36,18 @@ namespace LocalAppVeyor.Engine.Internal.Steps
                     switch (scriptLine.ScriptType)
                     {
                         case ScriptType.Batch:
-                            return ExecuteBatchScript(executionContext, scriptLine.Script);
+                            status = ExecuteBatchScript(executionContext, scriptLine.Script);
+                            break;
                         case ScriptType.PowerShell:
-                            return ExecutePowerShellScript(executionContext, scriptLine.Script);
+                            status = ExecutePowerShellScript(executionContext, scriptLine.Script);
+                            break;
+                        default:
+                            status = false;
+                            break;
+                    }
+                    if (!status)
+                    {
+                        return false;
                     }
                 }
             }


### PR DESCRIPTION
Execution was stopping after the first command in the install block because ```return Execute(line)```.  Instead, assign execute status to a flag, and only return if that flag is false.  

This behaviour will stop execution in the block at the first error; don't know what the corresponding behaviour is in AppVeyor.