### PR TITLE
fix(unix): case sensitivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dotnet tool install -g localappveyor
 You have it now available on your command line:
 
 ```console
-localappveyor --help
+LocalAppVeyor --help
 ```
 
 <sup>*Note: to use CLI tool command you must have [.NET Core 2.1](https://www.microsoft.com/net/download) or higher.*</sup>


### PR DESCRIPTION
### 1. Summary

I changed command in documentation, that it will available for Linux users.

### 2. Argumentation

`localappveyor` command not works on Linux, `LocalAppVeyor` — is a correct way.

See, for example, [**How-To Geek article**](https://www.howtogeek.com/137096/6-ways-the-linux-file-system-is-different-from-the-windows-file-system/):

> **Case Sensitivity**
>
> On Windows, you can’t have a file named file and another file named FILE in the same folder. The Windows file system isn’t case sensitive, so it treats these names as the same file.
>
> On Linux, the file system is case sensitive. This means that you could have files named file, File, and FILE in the same folder. Each file would have different contents – Linux treats capitalized letters and lower-case letters as different characters.

![Case Sensitivity](https://www.howtogeek.com/wp-content/uploads/2013/02/linux-file-case-sensitivity.png.pagespeed.ce.aK37Rhu6hs.png)

### 3. Demonstration

### 4. Environment

1. Travis CI [**default**](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) Linux [**configuration**](https://docs.travis-ci.com/user/reference/xenial/)

#### 4.1. Configuration

```yaml
# [INFO] Add DotNet tools directory to PATH
before_install:
- PATH=$PATH:$HOME/.dotnet/tools

# [INFO] Install .NET Core SDK on Linux:
# https://dotnet.microsoft.com/download/linux-package-manager/ubuntu16-04/sdk-current
install:
- wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
- sudo dpkg -i packages-microsoft-prod.deb
- sudo apt-get install apt-transport-https
- sudo apt-get update
- sudo apt-get install dotnet-sdk-2.2
- dotnet tool install -g localappveyor

script:
- LocalAppVeyor --help

```

The solely difference between configs below — `LocalAppVeyor` vs `localappveyor`.

+ [**LocalAppVeyor**](https://travis-ci.org/Kristinita/SashaTravisDebugging/jobs/587391298/config),
+ [**localappveyor**](https://travis-ci.org/Kristinita/SashaTravisDebugging/jobs/587392405/config).

### 5. Expected behavior

**If** `LocalAppVeyor`:

+ :heavy_check_mark: [**Success**](https://travis-ci.org/Kristinita/SashaTravisDebugging/jobs/587391298#L333):

```text
The command "LocalAppVeyor --help" exited with 0.
```

### 6. Unexpected behavior

**Else** `localappveyor`:

+ :x: [**No success**](https://travis-ci.org/Kristinita/SashaTravisDebugging/builds/587392404#L316-L317):

```text
localappveyor: command not found

The command "localappveyor --help" exited with 127.
```

Thanks.